### PR TITLE
Fix for the Assassin bee crashing servers and sided RF / Energy bee issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
-version = "0.4.0"
+version = "0.4.1"
 group = "com.rwtema.careerbees" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "careerbees"
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
-version = "0.4.1"
+version = "0.4.0"
 group = "com.rwtema.careerbees" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "careerbees"
 

--- a/src/main/java/com/rwtema/careerbees/effects/EffectAssassin.java
+++ b/src/main/java/com/rwtema/careerbees/effects/EffectAssassin.java
@@ -48,8 +48,6 @@ public class EffectAssassin extends EffectWorldInteraction {
 
 	@Override
 	protected boolean performPosEffect(World world, BlockPos blockPos, IBlockState state, IBeeGenome genome, IBeeHousing housing) {
-		if ( housing.getCoordinates() == blockPos )
-			return false;
 		if ( canHandleBlock(world, blockPos, genome, null) ) {
 			IBeeHousing house = (IBeeHousing) world.getTileEntity(blockPos);
 			ItemStack queenStack = house.getBeeInventory().getQueen();

--- a/src/main/java/com/rwtema/careerbees/effects/EffectAssassin.java
+++ b/src/main/java/com/rwtema/careerbees/effects/EffectAssassin.java
@@ -36,9 +36,11 @@ public class EffectAssassin extends EffectWorldInteraction {
 			return false;
 		if (tileEntity instanceof IBeeHousing) {
 			ItemStack queen = ((IBeeHousing) tileEntity).getBeeInventory().getQueen();
-			if (queen.isEmpty() || BeeManager.beeRoot.getType(queen) != EnumBeeType.QUEEN) return false;
+			if (queen.isEmpty() || BeeManager.beeRoot.getType(queen) != EnumBeeType.QUEEN)
+				return false;
 			IBee member = BeeManager.beeRoot.getMember(queen);
-			if (member == null) return false;
+			if (member == null)
+				return false;
 			IBeeGenome memberGenome = member.getGenome();
 			return memberGenome.getPrimary() != genome.getPrimary();
 		}
@@ -47,26 +49,20 @@ public class EffectAssassin extends EffectWorldInteraction {
 
 	@Override
 	protected boolean performPosEffect(World world, BlockPos blockPos, IBlockState state, IBeeGenome genome, IBeeHousing housing) {
-		// Fix bugs #22 #25 (do not work on source hive) and use the bee gun's canHandleBlock guard to fix bugs #23 #37
-		if (housing.getCoordinates() != blockPos &&
-			canHandleBlock(world, blockPos, genome, null)) {
-
+		if ( housing.getCoordinates() == blockPos )
+			return false;
+		if ( canHandleBlock(world, blockPos, genome, null) ) {
 			IBeeHousing house = (IBeeHousing) world.getTileEntity(blockPos);
-			// Guarded by canHandleBlock, this should always succeed.
-
 			ItemStack queenStack = house.getBeeInventory().getQueen();
 			IBee queen = BeeManager.beeRoot.getMember(queenStack);
 			if (queen == null || queenStack.isEmpty() || !queenStack.hasTagCompound())
 				return false;
-
 			queen.setHealth(0);
 			NBTTagCompound nbttagcompound = new NBTTagCompound();
 			queen.writeToNBT(nbttagcompound);
-			//BeeMod.logger.info("Assassin Bee profiled: " + queen + " as: " + nbttagcompound);
 			queenStack.setTagCompound(nbttagcompound);
 			house.getBeeInventory().setQueen(queenStack);
 			house.getBeekeepingLogic().canWork();
-			//BeeMod.logger.info("Assassin Bee reports back from: " + blockPos);
 			return true;
 		}
 		return false;

--- a/src/main/java/com/rwtema/careerbees/effects/EffectAssassin.java
+++ b/src/main/java/com/rwtema/careerbees/effects/EffectAssassin.java
@@ -1,6 +1,5 @@
 package com.rwtema.careerbees.effects;
 
-// import com.rwtema.careerbees.BeeMod; // logger
 import forestry.api.apiculture.*;
 import forestry.apiculture.PluginApiculture;
 import net.minecraft.block.state.IBlockState;

--- a/src/main/java/com/rwtema/careerbees/effects/EffectPower.java
+++ b/src/main/java/com/rwtema/careerbees/effects/EffectPower.java
@@ -51,6 +51,8 @@ public class EffectPower extends EffectBase implements ISpecialBeeEffect.Special
 			int energysent = storeRFTEFaces(TEFaces, energyleft);
 			//BeeMod.logger.info("EnergyBee sent " + energysent + " RF to " + pos + " " + TEFaces.te);
 			energyleft -= energysent;
+			if ( 0 == energyleft )
+				break;
 		}
 		return storedData;
 	}
@@ -112,6 +114,8 @@ public class EffectPower extends EffectBase implements ISpecialBeeEffect.Special
 				} else {
 					// BeeMod.logger.warn("EnergyBee couldn't get storage for the block at: " + pos);
 				}
+				if ( 0 == energyleft )
+					break;
 			}
 		}
 		return maxRF - energyleft; // energy used/sent


### PR DESCRIPTION
Thank you for helping to make Bees fun and worth doing in packs that include your mod (especially when combined with Gendustry).

While fixing a server crashing bug with the Assassin bees, I also looked over the other currently open issues and made the Energy bee work with sided blocks (by checking the null/internal side, as well as all the others).

Please accept this contribution of code.  As there isn't an existing license specified nor a contributor agreement to look at and since the additions are either purely derivative works or arguably the obvious way for someone skilled in the art to resolve the problem (and thus not fit for copyright alone): I grant non-revocable, transferable, non-exclusive (you have them, I have them for my contributions alone, etc) rights to the code that I have offered for addition in the combined work.

It should resolve the following bugs, and I have built and tested these locally in single player.

src/main/java/com/rwtema/careerbees/effects/EffectAssassin.java
Fix bugs #22 #25 (do not work on source hive)
Fix bugs #23 #37 (use canHandleBlock guard)
(and my issue) https://github.com/DarkPacks/Crackpack-3/issues/113
    
src/main/java/com/rwtema/careerbees/effects/EffectPower.java
Fix #17 (work on any valid side, including 'internal' / null) and refactored to de-duplicate code